### PR TITLE
remove stale logs at start of run

### DIFF
--- a/bin/grub_server
+++ b/bin/grub_server
@@ -28,6 +28,11 @@ tmpdir="${TMPDIR:-/tmp}"
 bld_out="${tmpdir}/grub.${local_user}_${server_name}_${repo}.out"
 bld_err="${tmpdir}/grub.${local_user}_${server_name}_${repo}.err"
 
+# Delete old log files to prevent displaying stale output from previous runs
+# This is critical when patch application fails - we don't want to show
+# old successful build output when the current build didn't actually run
+rm "${bld_out}" 2>/dev/null || true
+rm "${bld_err}" 2>/dev/null || true
 
 # Setup z/OS tagging and auto conversion
 if [ "${zos}" = "True" ]; then


### PR DESCRIPTION
Problem:
When patch application fails in grub_server, the script exits with error code 4,
but grub_client still displays the OLD cached content from previous successful
builds. This is misleading because it shows test results from a previous run,
not the current (failed) run.

Root cause:
- grub_server creates log files (bld_out, bld_err) but never deletes old content
- When patch fails, grub_server exits before writing new content
- grub_client downloads and displays whatever is in those files (old content)

Solution:
1. Delete old log files at the start of grub_server before any operations
2. This ensures that if the script exits early (patch failure), the files
   either don't exist or are empty, preventing display of stale output